### PR TITLE
Potential fix for code scanning alert no. 77: Information exposure through an exception

### DIFF
--- a/src/services/sigma_novelty_service.py
+++ b/src/services/sigma_novelty_service.py
@@ -502,7 +502,7 @@ class SigmaNoveltyService:
                 "novelty_score": 1.0,
                 "logsource_key": "",
                 "canonical_class": None,
-                "error": str(e),
+                "error": "Novelty assessment failed",
                 "top_matches": [],
                 "total_candidates_evaluated": 0,
                 "behavioral_matches_found": 0,


### PR DESCRIPTION
Potential fix for [https://github.com/dfirtnt/Huntable-CTI-Studio/security/code-scanning/77](https://github.com/dfirtnt/Huntable-CTI-Studio/security/code-scanning/77)

To fix this class of issue, never include raw exception details (`str(e)`, traceback text, internal messages) in objects returned to callers that can flow to HTTP responses. Keep detailed error context in server logs only, and return generic/safe error indicators in structured results.

Best fix with minimal functionality change:
- **File:** `src/services/sigma_novelty_service.py`
- **Region:** `assess_novelty(...)` exception handler (around lines 495–510 in provided snippet).
- Replace `"error": str(e)` with a generic non-sensitive value (for example `"error": "Novelty assessment failed"`), while keeping traceback logging on server side as-is.
- No new imports or dependencies are needed.

This preserves behavior (method still returns fallback novelty result) while removing sensitive exception disclosure from data that can propagate to API responses.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
