### PR TITLE
docs(agents): correct extract sub-agent dispatch as sequential

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -15,7 +15,7 @@ that schedules and distributes the work. Each agent writes results to
    ranking and extraction.
 2. **LLM ranking**: Scores article quality (1-10) and gates the rest of the
    workflow.
-3. **Extract Agent**: Runs sub-agents in parallel and merges their observables
+3. **Extract Agent**: Runs sub-agents sequentially and merges their observables
    into `extraction_result`.
 4. **Sigma generator**: Builds Sigma rules from extracted observables and
    validates with pySigma.


### PR DESCRIPTION
The Extract Agent runs its six sub-agents in a single LangGraph node via a for-loop with a blocking await on each iteration (src/workflows/agentic_workflow.py:1386, :1700), not in parallel. Update docs/concepts/agents.md to match the implementation.

https://claude.ai/code/session_01BqDPH8RdhVnrDguEznPVps