### PR TITLE
Potential fix for code scanning alert no. 526: Variable defined multiple times

### DIFF
--- a/src/services/sigma_huntability_scorer.py
+++ b/src/services/sigma_huntability_scorer.py
@@ -117,7 +117,6 @@ class SigmaHuntabilityScorer:
 
     def _score_commandline_specificity(self, detection: dict) -> float:
         """Score command-line specificity (0-1)."""
-        score = 0.0
 
         # Check for CommandLine field
         has_commandline = False


### PR DESCRIPTION
Potential fix for [https://github.com/dfirtnt/Huntable-CTI-Studio/security/code-scanning/526](https://github.com/dfirtnt/Huntable-CTI-Studio/security/code-scanning/526)

The general fix is to remove the dead initial assignment when a variable is always reassigned before use.

Best fix here: in `src/services/sigma_huntability_scorer.py`, inside `_score_commandline_specificity`, delete the line `score = 0.0`. The later conditional assignments (lines 155/157) remain unchanged, and `return score` still returns the same value on all paths. No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
