### PR TITLE
fix(docker): mount init-scripts directory instead of missing init.sql file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       TZ: America/New_York
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./init-scripts/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./init-scripts:/docker-entrypoint-initdb.d
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
## Summary

- Replaces the `./init-scripts/init.sql` file bind-mount with `./init-scripts:/docker-entrypoint-initdb.d` (directory mount)
- `init.sql` is not tracked in git and excluded by `.gitignore`, so Docker was creating a phantom **directory** at that path on fresh clones, causing postgres init to fail with "Is a directory"
- This also fixes `00_create_test_db.sh` not being mounted at all (it was in `init-scripts/` but never reached the container)

## Test plan

- [ ] Fresh clone + `docker compose up` — postgres starts healthy without manual intervention
- [ ] `cti_scraper_test` database is created on first init (via `00_create_test_db.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)