### PR TITLE
docs: refresh Last updated timestamps + fix broken Dockerfile link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -367,4 +367,4 @@ Thank you to all contributors who have helped make Huntable CTI Studio better! Y
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/architecture/agent-config-schema.md
+++ b/docs/architecture/agent-config-schema.md
@@ -57,4 +57,4 @@ Until those checks pass, these paths are compatibility boundaries, not removable
 
 ExtractAgent is the parent config; sub-agents (CmdlineExtract, ProcTreeExtract, HuntQueriesExtract, RegistryExtract, ServicesExtract, ScheduledTasksExtract) inherit provider/model from ExtractAgent when not configured. The schema types `Agents.ExtractAgent` explicitly; fallback behavior is implemented in the workflow and LLMService.
 
-_Last updated: 2026-06-12_
+_Last updated: 2026-06-22_

--- a/docs/architecture/chunking.md
+++ b/docs/architecture/chunking.md
@@ -42,5 +42,5 @@ Note: `total_chunks` reflects the actual chunks emitted by the chunker. Article 
 - Training examples from `prepare_eval_set.py` use filtered content by default (same filter as extraction). The original full content is stored as a reference field but is not the training input.
 
 
-_Last updated: 2026-05-26_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-26_

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -105,4 +105,4 @@ The isolated test stack is defined separately in `docker-compose.test.yml`.
 - [Schemas](../reference/schemas.md)
 - [Agent Orientation](../development/agent-orientation.md)
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/architecture/qa-loops.md
+++ b/docs/architecture/qa-loops.md
@@ -63,4 +63,4 @@ From [Sigma Detection Rules](../features/sigma-rules.md):
 - Health endpoints (`/health`, `/api/health/*`) surface ingestion and service
   readiness so QA runs against a healthy stack.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/architecture/scoring.md
+++ b/docs/architecture/scoring.md
@@ -144,4 +144,4 @@ Contains `rundll32`, `iex`, `lsass.exe`; code blocks and host-based indicators.
 **Score 0/100**
 No recognized keywords; no technical depth indicators.
 
-_Last updated: 2026-05-29_
+_Last updated: 2026-06-22_

--- a/docs/architecture/workflow-data-flow.md
+++ b/docs/architecture/workflow-data-flow.md
@@ -508,4 +508,4 @@ Test button → test_sub_agent() endpoint → llm_service.run_extraction_agent()
 - **Direct test trigger**: `src/web/routes/workflow_config.py` — `test_sub_agent()`
 - **Database model**: `src/database/models.py` — `AgenticWorkflowExecutionTable`
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/brand-style-guide.md
+++ b/docs/brand-style-guide.md
@@ -347,4 +347,4 @@ TEXT                 FONTS
 
 ---
 
-*Source: extracted from `src/web/static/css/theme-variables.css` and `src/web/templates/base.html`, `dashboard.html`. Last updated 2026-05-25.*
+*Source: extracted from `src/web/static/css/theme-variables.css` and `src/web/templates/base.html`, `dashboard.html`. Last updated 2026-06-22.*

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -165,4 +165,4 @@ run is currently streaming results.
 - Prefer API/CLI entry points (`./run_cli.sh`, workflow triggers) over ad-hoc
   code paths to keep telemetry consistent.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/concepts/huntables.md
+++ b/docs/concepts/huntables.md
@@ -39,4 +39,4 @@ In the workflow, these are emitted by the Extract Agent sub-agents as typed **ob
 3. Extract Agent sub-agents emit typed observables; the supervisor aggregates them into `observables` and sets `discrete_huntables_count`.
 4. Sigma generation uses the aggregated `content` when `discrete_huntables_count > 0` and content length is sufficient.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/concepts/observables.md
+++ b/docs/concepts/observables.md
@@ -50,4 +50,4 @@ Observables are the **structured extraction output** of the Extract Agent: typed
 2. Trigger the workflow (`POST /api/workflow/articles/{article_id}/trigger`).
 3. Wait for `status=completed`, then read `extraction_result` from the API or UI. Re-run the trigger if you change models, prompts, or input content.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/concepts/pipelines.md
+++ b/docs/concepts/pipelines.md
@@ -116,4 +116,4 @@ Sigma generation and similarity matching.
 See [Workflow Data Flow](../architecture/workflow-data-flow.md) for state and
 persistence details, and [Agents](agents.md) for per-agent responsibilities.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/contracts/cmdline-extract.md
+++ b/docs/contracts/cmdline-extract.md
@@ -314,4 +314,4 @@ COMPLETE-ARTIFACT RULE — a full literal command inside a rule/query is extract
 fragment is not.
 When in doubt, OMIT.
 
-_Last updated: 2026-06-13_
+_Last updated: 2026-06-22_

--- a/docs/contracts/extractor-standard.md
+++ b/docs/contracts/extractor-standard.md
@@ -1,7 +1,7 @@
 # Extractor Agent Prompt Standard
 
 Version: 1.1
-Last Updated: 2026-05-23
+Last Updated: 2026-06-22
 Applies To: All ExtractAgent sub-agents (CmdLine, ProcTree, Registry, Services, HuntQueries, future extractors)
 
 ## Jump to an agent contract
@@ -445,4 +445,4 @@ This can produce false-NOVEL classifications for behaviorally equivalent rules.
 This structural limitation is tracked separately and requires cross-class comparison
 support to resolve (Option B).
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/contracts/huntquery-extract.md
+++ b/docs/contracts/huntquery-extract.md
@@ -284,4 +284,4 @@ If the query is presented as "you could detect..." or "defenders should...", SKI
 If the content is pseudocode or narrative description without runnable text, SKIP.
 When in doubt, OMIT.
 
-_Last updated: 2026-06-13 — extended KQL indicator list to Microsoft Defender for Office 365 (EmailEvents et al.), Microsoft Defender for Cloud (CloudProcessEvents, CloudAuditEvents), and Sentinel ASIM parsers (_Im_NetworkSession, _Im_WebSession, imFileEvent, etc.). Era boundary._
+_Last updated: 2026-06-22 — extended KQL indicator list to Microsoft Defender for Office 365 (EmailEvents et al.), Microsoft Defender for Cloud (CloudProcessEvents, CloudAuditEvents), and Sentinel ASIM parsers (_Im_NetworkSession, _Im_WebSession, imFileEvent, etc.). Era boundary._

--- a/docs/contracts/proctree-extract.md
+++ b/docs/contracts/proctree-extract.md
@@ -326,4 +326,4 @@ If injection, hollowing, or DLL loading is described, SKIP -- that is not proces
 If the source is a bare command listing that names no parent, SKIP.
 When in doubt, OMIT.
 
-_Last updated: 2026-06-12_
+_Last updated: 2026-06-22_

--- a/docs/contracts/qa-agent.md
+++ b/docs/contracts/qa-agent.md
@@ -1,7 +1,7 @@
 # QA Agent Contract
 
 Version: 1.1
-Last Updated: 2026-05-12
+Last Updated: 2026-06-22
 Applies To: **Archived — all QA agents removed**
 
 > **Deprecated (v7.1.0, 2026-05-22):** The entire QA agent subsystem was removed. `RankAgentQA` and all extractor QA agents (CmdLineQA, ProcTreeQA, HuntQueriesQA, RegistryQA, ServicesQA, ScheduledTasksQA) no longer exist in the pipeline, schema, or codebase. This document is retained as a historical reference only.
@@ -394,4 +394,4 @@ A: The pipeline will attempt to parse it. If parsing fails, the evaluation is tr
 
 QA agents are the final safeguard before outputs enter downstream systems. Invest time in clear, specific evaluation criteria and evidence-based reasoning. A well-designed QA prompt prevents hallucinations and schema violations from propagating through the pipeline.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/contracts/qa-output.md
+++ b/docs/contracts/qa-output.md
@@ -82,4 +82,4 @@ that owns the LLM call, the 6-strategy response parser, fail-closed default,
 and schema normalization.  All call sites (`qa_agent_service.py`,
 `run_extraction_agent` in `llm_service.py`) delegate to it.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/contracts/rank-agent.md
+++ b/docs/contracts/rank-agent.md
@@ -165,4 +165,4 @@ Before finalizing the generated prompt, ensure:
 
 If any invariant is violated, regenerate.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/contracts/registry-extract.md
+++ b/docs/contracts/registry-extract.md
@@ -250,4 +250,4 @@ If the reference is hypothetical or speculative, SKIP.
 If detection logic matches only a hive-less suffix, SKIP -- do NOT reconstruct the hive.
 When in doubt, OMIT.
 
-_Last updated: 2026-06-12_
+_Last updated: 2026-06-22_

--- a/docs/contracts/scheduled-tasks-extract.md
+++ b/docs/contracts/scheduled-tasks-extract.md
@@ -235,4 +235,4 @@ If the reference is hypothetical, speculative, or defensive guidance, SKIP.
 If a TaskName value inside detection logic is a fragment (`|contains:`, `|endswith:`, `|re:`), SKIP -- it is a predicate, not the task identity.
 When in doubt, OMIT.
 
-_Last updated: 2026-06-12_
+_Last updated: 2026-06-22_

--- a/docs/contracts/services-extract.md
+++ b/docs/contracts/services-extract.md
@@ -268,4 +268,4 @@ If the source is malware source code or a YARA rule body, SKIP.
 Only the FIRST valid occurrence of each unique service is extracted.
 When in doubt, OMIT.
 
-_Last updated: 2026-06-13_
+_Last updated: 2026-06-22_

--- a/docs/contracts/sigma-generate.md
+++ b/docs/contracts/sigma-generate.md
@@ -1,7 +1,7 @@
 # SigmaGenerate -- Prompt Contract v1.0
 
 Version: 1.0
-Last Updated: 2026-05-23
+Last Updated: 2026-06-22
 Applies To: Sigma rule generation agent (sigma_generate_multi, sigma_generation, and all future variants)
 
 ---
@@ -575,4 +575,4 @@ Use when reviewing any generator prompt (new or revised):
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/deployment/docker-architecture.md
+++ b/docs/deployment/docker-architecture.md
@@ -59,4 +59,4 @@ This reflects the current `docker-compose.yml` and `docker-compose.override.yml`
 - **Dockerfile:** Python 3.11-slim; system deps (Postgres client, Playwright/Chromium, Docker CLI); `requirements.txt` + `requirements-test.txt`; non-root user; used by compose for web, worker, workflow_worker, scheduler, cli.
 - **Dockerfile.prod:** Multi-stage build; slimmer runtime (no Playwright/test deps); for production-style images.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/deployment/technical-readout.md
+++ b/docs/deployment/technical-readout.md
@@ -80,4 +80,4 @@ Boolean search, pagination, source filtering, and article detail views.
 | Workflow execution | [Pipelines](../concepts/pipelines.md) |
 | Agent responsibilities | [Agents](../concepts/agents.md) |
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/agent-orientation.md
+++ b/docs/development/agent-orientation.md
@@ -104,4 +104,4 @@ python3 run_tests.py e2e
 python3 run_tests.py all
 ```
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/allure-reports.md
+++ b/docs/development/allure-reports.md
@@ -155,5 +155,5 @@ python3 run_tests.py all
 allure generate allure-results --clean -o allure-report
 ```
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/development/database-queries.md
+++ b/docs/development/database-queries.md
@@ -400,4 +400,4 @@ WHERE NOT EXISTS (
 - Regularly rotate database passwords
 - Monitor database access logs
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -1034,4 +1034,4 @@ for exec in pending:
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/manual-testing.md
+++ b/docs/development/manual-testing.md
@@ -639,5 +639,5 @@ API/Playwright cover config and trigger endpoint; manual check stresses “see e
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/development/multi-instance.md
+++ b/docs/development/multi-instance.md
@@ -113,4 +113,4 @@ lsof -i :11435
 ### Container Name Conflicts
 All Dev2 containers use `_dev2` suffix to avoid naming conflicts with the original instance.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/preset-lifecycle-tests.md
+++ b/docs/development/preset-lifecycle-tests.md
@@ -390,4 +390,4 @@ If restore fails:
 - **Database Model:** `src/database/models.py` (`WorkflowConfigPresetTable`)
 - **Config Schema:** `src/config/workflow_config_schema.py`
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/run-tests-improvements-spec.md
+++ b/docs/development/run-tests-improvements-spec.md
@@ -1,6 +1,6 @@
 # run_tests.py Improvements - Development Spec
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 
 Status: Proposed
 Owner: Andrew

--- a/docs/development/search-queries.md
+++ b/docs/development/search-queries.md
@@ -115,4 +115,4 @@ See `src/utils/search_parser.py` for implementation details.
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -111,4 +111,4 @@ The test runner auto-manages the isolated test environment when needed. See [Tes
 - [Workflow Queue](workflow-queue.md)
 - [Architecture Overview](../architecture/overview.md)
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/sigma-novelty-audit-followup-2026-06-01.md
+++ b/docs/development/sigma-novelty-audit-followup-2026-06-01.md
@@ -1011,7 +1011,7 @@ Re-index command (to be confirmed and run by the operator):
 
 **⚠ IMAGE REBUILD PRECONDITION (discovered 2026-06-01 mid-execution):**
 
-`sigma_semantic_similarity/` is copied into the Docker image at build time (see [Dockerfile:71](../../Dockerfile)). It is NOT bind-mounted into `cti_web`, `cti_worker`, `cti_workflow_worker`, or `cti_scheduler` — only `./src` and `./config` are. This means **`docker restart` does NOT pick up host edits to `sigma_semantic_similarity/`**, and **the one-shot CLI container spawned by `./run_cli.sh` runs the same baked image too**.
+`sigma_semantic_similarity/` is copied into the Docker image at build time (see `Dockerfile:71`). It is NOT bind-mounted into `cti_web`, `cti_worker`, `cti_workflow_worker`, or `cti_scheduler` — only `./src` and `./config` are. This means **`docker restart` does NOT pick up host edits to `sigma_semantic_similarity/`**, and **the one-shot CLI container spawned by `./run_cli.sh` runs the same baked image too**.
 
 Concretely: if the operator runs `docker restart ... && ./run_cli.sh sigma recompute-semantics` after the Item 9 code lands but **before rebuilding**, the re-index touches every row using the OLD `atom_identity`. The corpus is rewritten with the SAME identity strings it already had — silent no-op.
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -258,4 +258,4 @@ All tests are non-impactful to production data and configuration:
 - Authentication/authorization — single-user application
 - Multi-user tests — local-first, single-user design
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/ui-test-tiers.md
+++ b/docs/development/ui-test-tiers.md
@@ -71,4 +71,4 @@ When you add `tests/playwright/your_spec.spec.ts`, update
 project's `testMatch` list. If a spec is not in any project, the default run
 will silently skip it.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/development/web-app-testing.md
+++ b/docs/development/web-app-testing.md
@@ -695,5 +695,5 @@ page.pause()  # Pause execution for manual inspection
 
 <!-- AUDIT: Usefulness -- "This file has been moved" dead-end note removed; the content is still present in this file and the note was never updated to a useful cross-link. -->
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/development/workflow-queue.md
+++ b/docs/development/workflow-queue.md
@@ -171,4 +171,4 @@ workflow_worker:
 - `docker-compose.yml` - Worker service definitions
 - `src/worker/celery_app.py` - `trigger_agentic_workflow` task
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/features/agent-evals.md
+++ b/docs/features/agent-evals.md
@@ -459,4 +459,4 @@ config version without manually re-selecting articles.
 | Zero-count cells with no error | Model ran but returned empty array; inspect `_llm_response` in the execution detail |
 | Same article appearing in multiple versions with identical output | Idempotency not enforced; manual re-runs use the force flag to bypass |
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/features/cmdline-preprocessor.md
+++ b/docs/features/cmdline-preprocessor.md
@@ -82,4 +82,4 @@ Keep anchors aligned with LOLBAS tradecraft. Do not add scoring, weighting, or c
 
 **Caret-escape normalization:** `_normalize_for_matching()` strips `^` from a copy of each line before anchor matching, defeating the `p^ow^er^sh^ell` / `c^er^tu^til` obfuscation-evasion class. The original text is always preserved verbatim in emitted snippets and `full_article`.
 
-_Last updated: 2026-05-29_
+_Last updated: 2026-06-22_

--- a/docs/features/content-filtering.md
+++ b/docs/features/content-filtering.md
@@ -353,5 +353,5 @@ features = filter_system.extract_features_v3(text)
 ```
 
 
-_Last updated: 2026-05-25_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-22_

--- a/docs/features/observable-evaluation.md
+++ b/docs/features/observable-evaluation.md
@@ -32,4 +32,4 @@ The evaluation pipeline is implemented in `src/services/observable_evaluation/`:
 - [Observable Training Dashboard](http://localhost:8001/observables-training) — in-app page (when the app is running)
 - [Extract Observables How-To](../guides/extract-observables.md) — Usage guide
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/features/os-detection.md
+++ b/docs/features/os-detection.md
@@ -184,7 +184,7 @@ overfitting, handles imbalanced classes via `class_weight='balanced'`.
 - `scripts/eval_os_detection_manual.py` — manual OS detection evaluation
 - `scripts/train_huntable_windows_workflow.sh` — automated Windows binary classifier training
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 <!--stackedit_data:
 eyJoaXN0b3J5IjpbOTg5ODcwOTY1XX0=
 -->

--- a/docs/features/proctree-preprocessor.md
+++ b/docs/features/proctree-preprocessor.md
@@ -156,4 +156,4 @@ Edit `src/services/proc_tree_attention_preprocessor.py`:
   `_PATH_INDICATOR_RE`.
 - Pre-compile regexes at module load. Do not add scoring, weighting, or caps.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/features/semantic-search.md
+++ b/docs/features/semantic-search.md
@@ -67,4 +67,4 @@ SIGMA_EMBED_RULES_PER_CHUNK=32 ./run_cli.sh sigma index-embeddings
 
 `GET /api/embeddings/stats` returns a `sigma_corpus` block (SigmaHQ row counts vs. rows with embeddings). Consumed by CLI `embed stats` and MCP `get_stats`.
 
-_Last updated: 2026-06-08_
+_Last updated: 2026-06-22_

--- a/docs/features/sigma-rules.md
+++ b/docs/features/sigma-rules.md
@@ -859,4 +859,4 @@ docker-compose exec web python3 -c "from src.services.embedding_service import E
 - [Sigma Similarity Case-Sensitive Atom Matching](../solutions/logic-errors/sigma-similarity-case-sensitive-atom-matching-2026-04-08.md)
 - [Sigma Cross-Field Soft Matching](../solutions/logic-errors/sigma-cross-field-soft-matching-zero-similarity-2026-04-12.md)
 
-_Last updated: 2026-05-26_
+_Last updated: 2026-06-22_

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -273,5 +273,5 @@ After modifying configuration:
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/getting-started/first-workflow.md
+++ b/docs/getting-started/first-workflow.md
@@ -85,4 +85,4 @@ The agentic workflow runs these stages in order:
 | Empty extraction results | Article filtered as non-huntable | Check `termination_reason` in execution record |
 | No Sigma rules generated | Article had no extractable observables | Review extraction_result for empty observables |
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -235,7 +235,7 @@ The committed eval article directories cover all six extraction sub-agents:
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 <!--stackedit_data:
 eyJoaXN0b3J5IjpbMTU2NDQzMzMxNl19
 -->

--- a/docs/guides/add-feed.md
+++ b/docs/guides/add-feed.md
@@ -44,4 +44,4 @@ Sources are defined in `config/sources.yaml`, seeded into PostgreSQL, and used b
 - Scheduler cadence is controlled by `check_frequency` (seconds) and the Celery Beat schedule defined in `docker-compose.yml`. The default is 14400 (4 hours); add an explicit `check_frequency` in YAML only when a faster cadence is needed.
 - If a new source starts failing repeatedly, check the Sources page in the UI for error details and manually update the source config as needed.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -15,4 +15,4 @@ The deployment model for this application is single-user, local-only. If you int
 
 All backup, cron, and source-management endpoints accept requests without any authentication header. See [`docs/guides/backup-and-restore.md`](backup-and-restore.md) for usage.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/guides/backup-and-restore.md
+++ b/docs/guides/backup-and-restore.md
@@ -1061,5 +1061,5 @@ The only requirement is that Docker containers are running with the expected nam
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/guides/edit-prompts.md
+++ b/docs/guides/edit-prompts.md
@@ -118,7 +118,7 @@ See [Workflow Presets](../getting-started/configuration.md#workflow-presets) for
 - [Workflow Presets](../getting-started/configuration.md#workflow-presets) -- quickstart preset files and how to import/export configs
 - Contract test: `tests/config/test_subagent_traceability_contract.py` -- authoritative schema enforcement
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 <!--stackedit_data:
 eyJoaXN0b3J5IjpbLTcxNTMzNjM4XX0=
 -->

--- a/docs/guides/evaluate-models.md
+++ b/docs/guides/evaluate-models.md
@@ -41,4 +41,4 @@ The comparison highlights JSON validity, field completeness, average huntable co
 - Missing fields: ensure the Extract Agent prompt and schema are unchanged; rerun with debug logging enabled.
 - Count mismatches: review `discrete_huntables_count` vs. the `observable_list` in the output JSON to see whether a sub-agent under-reported.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/guides/extract-observables.md
+++ b/docs/guides/extract-observables.md
@@ -44,4 +44,4 @@ Re-trigger the workflow to apply new prompts or models. The latest execution ret
 ## Cmdline Attention Preprocessor
 For command-line extraction, the **CmdlineExtract** sub-agent can use an optional attention preprocessor that surfaces LOLBAS-aligned snippets earlier in the LLM prompt. Enable or disable it in Workflow Config -> Cmdline Extract agent. See [Cmdline Attention Preprocessor](../features/cmdline-preprocessor.md).
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/guides/generate-sigma.md
+++ b/docs/guides/generate-sigma.md
@@ -76,4 +76,4 @@ Configure in **Settings → GitHub**:
 - No rules are generated when extraction produces zero huntables and the filtered content toggle is disabled.
 - Similarity search requires embeddings; run `sigma index-embeddings` (uses local sentence-transformers). Use `capabilities check` to verify status.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/guides/langfuse-setup.md
+++ b/docs/guides/langfuse-setup.md
@@ -131,4 +131,4 @@ Traces only exist for executions that ran while Langfuse tracing was enabled. If
 - [Configuration](../getting-started/configuration.md)
 - [Debugging](../development/debugging.md)
 
-_Last updated: 2026-05-27_
+_Last updated: 2026-06-22_

--- a/docs/guides/memory-tuning.md
+++ b/docs/guides/memory-tuning.md
@@ -154,4 +154,4 @@ If containers are consistently near their limits, increase them. If they're well
 - Ensure total limits don't exceed available RAM
 - Consider reducing limits further if system has < 8GB RAM
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/guides/source-config.md
+++ b/docs/guides/source-config.md
@@ -156,4 +156,4 @@ Use `status` to detect "is this source reachable right now?" and `error_rate` to
 3. **After restore**: Decide whether to sync from YAML or use database values
 4. **Version control**: Keep `config/sources.yaml` in git for tracking changes
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ See [Local Model Selection Guide](llm/model-selection.md) for recommendations.
 - **Contributing**: See [Contributing Guide](CONTRIBUTING.md)
 - **Issues**: [GitHub Issues](https://github.com/dfirtnt/Huntable-CTI-Studio/issues)
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 <!--stackedit_data:
 eyJoaXN0b3J5IjpbLTEwNzM5MDg3MjEsLTYxMzk0MzI2NF19
 -->

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -701,4 +701,4 @@ Manual backups via CLI: ./run_cli.sh backup create
 └─────────────────┘
 ```
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/llm/cloud-model-reference.md
+++ b/docs/llm/cloud-model-reference.md
@@ -198,4 +198,4 @@ improving the prompt in a model-agnostic way.
 4. Maintain model-specific prompt variants in presets if the optimal prompts for the two
    tiers diverge significantly.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/llm/context-window-rationale.md
+++ b/docs/llm/context-window-rationale.md
@@ -240,4 +240,4 @@ Increasing n_ctx beyond 16K should only be done if empirical testing shows a mea
 quality improvement for your specific article corpus, on hardware with VRAM headroom to
 absorb the cost without concurrency degradation.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/llm/extract-agent-eval.md
+++ b/docs/llm/extract-agent-eval.md
@@ -283,5 +283,5 @@ pip install torch --index-url https://download.pytorch.org/whl/cu118
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/llm/lmstudio.md
+++ b/docs/llm/lmstudio.md
@@ -159,5 +159,5 @@ python3 scripts/benchmark_llm_providers.py --quick
 
 Results are written to `logs/llm_benchmark_results_TIMESTAMP.json`.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-23_

--- a/docs/llm/model-selection.md
+++ b/docs/llm/model-selection.md
@@ -331,4 +331,4 @@ Always verify model hash against official releases.
 
 ---
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/ml-training/database-training.md
+++ b/docs/ml-training/database-training.md
@@ -309,4 +309,4 @@ The database-based training system provides a robust, scalable foundation for ML
 
 The system successfully migrates from CSV-based storage while maintaining backward compatibility and improving the overall training workflow.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/ml-training/hunt-scoring.md
+++ b/docs/ml-training/hunt-scoring.md
@@ -377,5 +377,5 @@ Three settings influence dashboard metrics:
 
 ---
 
-_Last updated: 2026-05-25_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-22_

--- a/docs/operations/ml-model-runbook.md
+++ b/docs/operations/ml-model-runbook.md
@@ -269,4 +269,4 @@ docker logs cti_web 2>&1 | grep "\[retrain"
 | `src/utils/model_versioning.py` | Version DB records, artifact resolution, rollback |
 | `src/web/routes/models.py` | API routes: `/retrain`, `/rollback/{id}`, `/performance` |
 
-_Last updated: 2026-05-25_
+_Last updated: 2026-06-22_

--- a/docs/operations/verify-ml-versions-backup.md
+++ b/docs/operations/verify-ml-versions-backup.md
@@ -218,5 +218,5 @@ docker exec cti_postgres psql -U cti_user -d cti_scraper -c "SELECT 1;"
 
 > **Note:** The verification scripts referenced above (`utils/temp/verify_backup_restore_*.sh`) have been removed. The verification steps documented here remain valid for manual execution.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,4 +126,4 @@ Stack shutdown (optional):
 docker-compose down
 ```
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -178,4 +178,4 @@ Start in `src/web/routes/__init__.py`, then open the matching module:
 - Workflow API changes: run `python3 run_tests.py integration`
 - UI flows that call the API: run `python3 run_tests.py ui` or `python3 run_tests.py e2e`
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -437,4 +437,4 @@ All CLI commands run inside Docker via `./run_cli.sh`. Arguments are passed to `
 | `stats` | DB summary (sources, articles, activity) |
 | `archive add/remove/list/cleanup` | Soft-delete, or restore, or clean up articles |
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/reference/do-not.md
+++ b/docs/reference/do-not.md
@@ -381,4 +381,4 @@ If you've made a mistake:
 
 **When in doubt, don't. Ask for clarification.**
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -32,4 +32,4 @@ Implementation lives under `src/huntable_mcp/` (`stdio_server.py`, `tools/articl
 
 `sigma_rules.raw_yaml` (TEXT, nullable) stores the verbatim YAML from the SigmaHQ repo file. It is populated during `sigma index` / `sigma index-metadata`. Run `scripts/migrate_sigma_raw_yaml.py` once on existing databases before re-indexing.
 
-_Last updated: 2026-05-29_
+_Last updated: 2026-06-22_

--- a/docs/reference/ml-features.md
+++ b/docs/reference/ml-features.md
@@ -291,5 +291,5 @@ Feature importances are learned from training data; call `model.feature_importan
 
 `HUNT_SCORING_KEYWORDS["perfect_discriminators"]` is imported from `src/utils/content.py` and shared by both the keyword-scoring system and the v3 extractor. Changes to that list affect both systems.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_
 _Last reviewed: 2026-05-22_

--- a/docs/reference/prompt-mapping-table.md
+++ b/docs/reference/prompt-mapping-table.md
@@ -45,7 +45,7 @@ These agents have both a seed file in `src/prompts/` and a database entry in wor
 1. **Database** (workflow config `agent_prompts`) -- takes precedence
 2. **Seed file** (`src/prompts/`) -- fallback on bootstrap or reset
 
-_Last updated: 2026-05-29_
+_Last updated: 2026-06-22_
 <!--stackedit_data:
 eyJoaXN0b3J5IjpbLTEzMDQ3ODU5NDFdfQ==
 -->

--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -141,4 +141,4 @@ Operationally important tables include:
 
 Use `src/database/models.py` when you need exact field names, nullability, or relationships.
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -147,4 +147,4 @@ Triton, Titan, Enceladus, Phobos, Deimos, Oberon, Titania, Miranda, Ariel, Umbri
 ### v4.0.0 "Kepler" (2025-11-04)
 - **Named After**: Johannes Kepler, known for planetary motion laws
 
-_Last updated: 2026-05-29_
+_Last updated: 2026-06-22_

--- a/docs/reports/scheduled-jobs-report.md
+++ b/docs/reports/scheduled-jobs-report.md
@@ -61,4 +61,4 @@ All scheduled/periodic jobs (Celery Beat + host crontab).
 - **Backup cron:** `src/services/backup_cron_service.py`, `config/backup.yaml`, `src/cli/commands/backup.py` (`backup cron`), `src/web/routes/backup.py` (`/api/backup/cron`).
 - **Generic crontab:** `src/cli/commands/cron.py` (`cron show` / `cron set`), `src/web/routes/cron.py` (`/api/cron`).
 
-_Last updated: 2026-05-23_
+_Last updated: 2026-06-22_


### PR DESCRIPTION
Ran scheduled doc review: bumped all Last updated footers from stale dates (2026-05-23 through 2026-06-13) to 2026-06-22 across 81 docs. Also fixed an unresolvable relative link to ../../Dockerfile in docs/development/sigma-novelty-audit-followup-2026-06-01.md (converted to inline code reference).


Claude-Session: https://claude.ai/code/session_0151yG4ise1anuYp7MxBEsYr