### PR TITLE
ci(docs): combined Pages deploy on main (host root + /europa together)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,17 @@
 name: Docs
 
+# GitHub Pages hosts ONE site, and actions/deploy-pages replaces it wholesale on
+# every deploy. To host main at the site root AND europa-dev at /europa, every
+# deploy must publish the COMPLETE site — both refs built into a single _site/
+# tree — no matter which branch triggered it. Building only the triggering ref
+# would wipe the other (root or /europa) on each push. See also: this workflow
+# must exist on BOTH main and europa-dev to be fully robust, since Actions runs
+# the copy of the YAML on the pushed branch.
+
 on:
   workflow_dispatch:
   push:
-    branches: [main, dev-europa]
+    branches: [main, europa-dev]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -17,17 +25,19 @@ permissions:
   pages: write
   id-token: write
 
+# Serialize Pages deploys; never cancel a deploy already in flight.
 concurrency:
-  group: docs-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: docs-pages
+  cancel-in-progress: false
 
 jobs:
   build:
     name: MkDocs Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - name: Checkout
+      # Triggering ref — provides pyproject/uv.lock for the build environment.
+      - name: Checkout (build env)
         uses: actions/checkout@v6
 
       - name: Setup Python
@@ -43,45 +53,46 @@ jobs:
       - name: Install locked dependencies
         run: uv sync --frozen --no-group test --no-group dev
 
-      - name: Build docs
+      # ---- Pull requests: validate the PR ref only (strict), never deploy. ----
+      - name: Build (PR validation, strict)
+        if: github.event_name == 'pull_request'
         run: uv run --frozen --no-group test --no-group dev mkdocs build --strict
 
-      - name: Debug context
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-          REF_NAME: ${{ github.ref_name }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          echo "=== GitHub Context Debug ==="
-          echo "event_name=$EVENT_NAME"
-          echo "ref=$REF"
-          echo "ref_name=$REF_NAME"
-          echo "head_ref=$HEAD_REF"
-          ls -la | head -20
-          ls -la site/ | head -20
+      # ---- Push / manual dispatch: assemble the COMBINED site. ----
+      # Check out both publishable refs into sibling paths and build each into the
+      # one _site tree: main -> root, europa-dev -> /europa. Deterministic
+      # regardless of which branch triggered the run.
+      - name: Checkout main docs
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: docs-src/main
 
-      - name: Prepare site structure (main)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p staging
-          cp -r site/* staging/
+      - name: Checkout europa-dev docs
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: europa-dev
+          path: docs-src/europa
 
-      - name: Prepare site structure (dev-europa)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev-europa'
-        run: |
-          mkdir -p staging/europa
-          cp -r site/* staging/europa/
+      - name: Build main -> site root (strict)
+        if: github.event_name != 'pull_request'
+        run: uv run --frozen --no-group test --no-group dev mkdocs build --strict -f docs-src/main/mkdocs.yml --site-dir "$GITHUB_WORKSPACE/_site"
+
+      - name: Build europa-dev -> /europa (strict)
+        if: github.event_name != 'pull_request'
+        run: uv run --frozen --no-group test --no-group dev mkdocs build --strict -f docs-src/europa/mkdocs.yml --site-dir "$GITHUB_WORKSPACE/_site/europa"
 
       - name: Upload pages artifact
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev-europa')
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/europa-dev'))
         uses: actions/upload-pages-artifact@v5
         with:
-          path: staging/
+          path: _site
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev-europa')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/europa-dev'))
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## What

Brings the **combined-deploy** Docs workflow (already on `europa-dev`) to `main`.

## Why

GitHub Pages hosts one site, and `actions/deploy-pages` **replaces it wholesale on every deploy**. The previous workflow built only the triggering branch and staged it per-branch (`main` to root, `europa-dev` to `/europa`) — so the two deploys clobbered each other. In practice, an `europa-dev` deploy wiped the `main` site root (root went **404**).

A workflow runs the copy of its YAML on the branch being pushed, so the combined fix must live on **both** branches. It is on `europa-dev`; this closes the gap on `main`. Until then, a direct docs push to `main` would drop `/europa` until the next `europa-dev` deploy.

## How

Every push/dispatch now checks out **both** refs and builds them into one `_site/` artifact:
- `main` to site root (`--strict`)
- `europa-dev` to `/europa` (`--strict`)

PRs still do a single strict build (no deploy). Adds `workflow_dispatch` deploy for manual redeploys/recovery.

## Validation

Verified on `europa-dev` via `workflow_dispatch` (run `27990799585`): root (`main` docs) and `/europa` (`europa-dev` docs, with the new nav) both serve **200** simultaneously.

> Note: this PR only changes `.github/workflows/docs.yml`, which is outside the Docs workflow's `docs/**`/`mkdocs.yml` path filter — so merging it will not itself trigger a docs deploy. The next docs push to `main` (or a manual `workflow_dispatch`) picks up the combined behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
