### PR TITLE
fix(security): bump GitPython, pypdf, pymdown-extensions to clear dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,10 @@ dependencies = [
     "python-multipart==0.0.32",
     "cryptography==50.0.0",
     # PDF processing
-    "pypdf==6.14.2", # CVE-2026-54530/54531 + GHSA-jm82-fx9c-mx94 fixes
+    "pypdf==6.15.0", # CVE-2026-54530/54531 + GHSA-jm82-fx9c-mx94 + CVE-2026-71852/71870 fixes
     # SIGMA rule validation
     "pysigma==1.3.3",
-    "GitPython==3.1.57",
+    "GitPython==3.1.58", # 5 GHSA advisories fixed in 3.1.58; still zero import sites (flagged for removal)
     # AI/ML
     # torch 2.13.0: bumped from 2.12.1 solely to relax its transitive `setuptools<82` floor
     # (2.13.0 requires setuptools>=77.0.3, no ceiling) so the PYSEC-2026-3447 setuptools fix
@@ -86,7 +86,7 @@ dependencies = [
     "langsmith==0.8.18", # CVE-2026-45134 + GHSA-f4xh-w4cj-qxq8 fixes; exact pin mirrors requirements.txt
     "Mako==1.3.12", # path traversal + CVE-2026-44307 fixes
     "idna==3.16", # CVE-2026-45409 fix; exact pin closes supply-chain window on uv lock re-runs
-    "pymdown-extensions==11.0.0", # CVE-2026-46338 fix; exact pin closes supply-chain window on uv lock re-runs
+    "pymdown-extensions==11.0.1", # CVE-2026-46338 + CVE-2026-67422 fixes; exact pin closes supply-chain window on uv lock re-runs
     "PyJWT==2.13.0", # CVE PYSEC-2026-175/177/178/179; transitive via mcp[cli] (sole parent), exact pin per single-parent convention
     "setuptools>=83.0.0", # PYSEC-2026-3447 fix; >= since spacy/thinc/torch all depend on it (multi-parent, no single floor to == pin)
     # Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,11 +66,11 @@ python-multipart==0.0.32
 cryptography==50.0.0  # CVE-2026-34073, CVE-2026-39892 + GHSA-537c-gmf6-5ccf (vulnerable bundled OpenSSL) fixes
 
 # PDF processing
-pypdf==6.14.2  # CVE-2026-54530/54531 (infinite-loop DoS) + GHSA-jm82-fx9c-mx94 fixes
+pypdf==6.15.0  # CVE-2026-54530/54531 (infinite-loop DoS) + GHSA-jm82-fx9c-mx94 + CVE-2026-71852/71870 fixes
 
 # SIGMA rule validation and repository management
 pysigma==1.3.3
-GitPython==3.1.57
+GitPython==3.1.58  # 5 GHSA advisories fixed in 3.1.58; zero import sites (flagged for removal)
 
 # Additional AI/ML dependencies for enhanced features
 torch==2.13.0  # For advanced ML models; bumped to relax transitive setuptools<82 floor for PYSEC-2026-3447
@@ -99,7 +99,7 @@ langsmith==0.8.18  # streaming token events bypass output redaction + GHSA-f4xh-
 Mako==1.3.12  # path traversal + CVE-2026-44307 fixes
 python-multipart==0.0.32  # DoS (preamble/epilogue, negative Content-Length) + Content-Disposition/querystring parameter smuggling fixes (<0.0.31)
 idna==3.16  # CVE-2026-45409 fix; exact pin, mirrors pyproject.toml
-pymdown-extensions==11.0.0  # CVE-2026-46338 fix
+pymdown-extensions==11.0.1  # CVE-2026-46338 + CVE-2026-67422 fixes
 PyJWT==2.13.0  # CVE PYSEC-2026-175/177/178/179; transitive via mcp[cli]
 setuptools>=83.0.0  # PYSEC-2026-3447 fix; >= since spacy/thinc/torch all depend on it (multi-parent)
 

--- a/uv.lock
+++ b/uv.lock
@@ -866,7 +866,7 @@ wheels = [
 
 [[package]]
 name = "cti-scraper"
-version = "7.6.0"
+version = "7.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "accelerate", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
@@ -991,7 +991,7 @@ requires-dist = [
     { name = "extruct", specifier = "==0.18.0" },
     { name = "fastapi", specifier = "==0.136.3" },
     { name = "feedparser", specifier = "==6.0.12" },
-    { name = "gitpython", specifier = "==3.1.57" },
+    { name = "gitpython", specifier = "==3.1.58" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "idna", specifier = "==3.16" },
     { name = "iocextract", specifier = "==1.16.1" },
@@ -1020,8 +1020,8 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pyjwt", specifier = "==2.13.0" },
-    { name = "pymdown-extensions", specifier = "==11.0.0" },
-    { name = "pypdf", specifier = "==6.14.2" },
+    { name = "pymdown-extensions", specifier = "==11.0.1" },
+    { name = "pypdf", specifier = "==6.15.0" },
     { name = "pysigma", specifier = "==1.3.3" },
     { name = "pytesseract", specifier = "==0.3.13" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
@@ -1478,14 +1478,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
 ]
 
 [[package]]
@@ -3942,15 +3942,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -3964,11 +3964,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes dependabot alerts: high/medium severity for the following packages on main.

## Changes

| Package | From | To | Advisories fixed | Alerts |
|---|---|---|---|---|
| GitPython | 3.1.57 | 3.1.58 | GHSA-hmq2-w58f-27jc, GHSA-jm78-9fvv-mhgr, GHSA-wvpp-8hx9-p66j, GHSA-hh9p-6wh2-4mfc, GHSA-9rj7-rf2p-w77r, GHSA-4gmw-gg2m-w46p | 338-349 (6 high, 2 medium) |
| pypdf | 6.14.2 | 6.15.0 | GHSA-fp3f-mc75-235c, GHSA-fwg2-594c-jp42 | 352-353 (2 medium) |
| pymdown-extensions | 11.0.0 | 11.0.1 | GHSA-gm37-52c6-37mw | 350-351 (2 high) |

Pins applied in `pyproject.toml` and mirrored in `requirements.txt`; `uv.lock` regenerated (touches exactly these three stanzas plus the root cti-scraper version 7.6.0 -> 7.7.0, matching pyproject).

## Verification

- `uv lock --check` clean
- `uv sync --frozen` resolves (CI will confirm)
- Manifest files byte-identical to the version already validated on `europa-dev` (commit 9e536f9c)

Merge with a merge commit per house flow.